### PR TITLE
Support arrow key navigation in execution model example

### DIFF
--- a/examples/executionModel/application.js
+++ b/examples/executionModel/application.js
@@ -15,6 +15,7 @@ var Application = function () {
     buildAnimation();
 
     registerClickHandler();
+    registerKeypressHandler();
 
     render();
   };
@@ -155,6 +156,27 @@ var Application = function () {
     } else if (control.id === "previous") {
       self.animation.previousFrame();
       render();
+    }
+  };
+
+  var registerKeypressHandler = function () {
+    document.addEventListener("keydown", function (event) {
+      handleKeypress(event.keyCode);
+    });
+  };
+
+  var handleKeypress = function (keyCode) {
+    switch (keyCode) {
+      case 37:
+        event.preventDefault();
+        self.animation.previousFrame();
+        render();
+        break;
+      case 39:
+        event.preventDefault();
+        self.animation.nextFrame();
+        render();
+        break;
     }
   };
 


### PR DESCRIPTION
This makes the left/right arrow keys navigate between frames, which is a little easier than clicking on the controls.

The event listener is bound to the entire document rather than to the canvas, because a) canvases aren’t usually focusable, b) they can be made focusable by adding a `tabindex` but then they get an ugly blue border when they’re focused, but mostly c) having to click on the canvas first is annoying, so it’s better when the arrow keys just always work.